### PR TITLE
hotfix: MAContainer supports access by name, not only by index

### DIFF
--- a/Magritte/MAContainerTest.py
+++ b/Magritte/MAContainerTest.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from copy import copy
 from MAContainer_class import MAContainer
 from accessors.MAIdentityAccessor_class import MAIdentityAccessor
+from MAStringDescription_class import MAStringDescription
 
 
 class MAContainerTest(TestCase):
@@ -153,3 +154,14 @@ class MAContainerTest(TestCase):
     def test_keysAndValuesDo(self):
         self.inst1.setChildren([1, 2, 3, 4])
         self.assertEqual(self.inst1.keysAndValuesDo(self.block2), None)
+    
+    def test_searchByName(self):
+        desc = MAContainer()
+        desc += MAStringDescription(name = "first", label = "First Field")
+        desc += MAStringDescription(label = "nameless #2")
+        desc += MAStringDescription(name = "second", label = "Second Field")
+        desc += MAStringDescription(label = "nameless #1")
+        
+        self.assertEqual(desc["first"].label, "First Field")
+        self.assertEqual(desc["second"].label, "Second Field")
+        self.assertIsNone(desc["third"])

--- a/Magritte/MAContainer_class.py
+++ b/Magritte/MAContainer_class.py
@@ -27,7 +27,10 @@ class MAContainer(MADescription):
         return len(self._children)
 
     def __getitem__(self, item):
-        return self._children[item]
+        if(isinstance(item, str)):
+            return self._getByName(item)
+        else:
+            return self._children[item]
 
     def __copy__(self):
         clone = self.__class__()
@@ -148,6 +151,9 @@ class MAContainer(MADescription):
 
     def keysAndValuesDo(self, aBlock):
         for index, item in enumerate(self.children): aBlock(index, item)
+    
+    def _getByName(self, nameOfDescriptionToSearchFor):
+        return self.detectIfNone(lambda description: description.name == nameOfDescriptionToSearchFor, lambda: None)
 
     def acceptMagritte(self, aVisitor):
         aVisitor.visitContainer(self)


### PR DESCRIPTION
особенно полезно для наследования - когда надо немного _изменить_ поле в дескрипторе, который достался от предка