### PR TITLE
MAContainer inheritance

### DIFF
--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -192,19 +192,19 @@ class MAContainer(MADescription):
     def acceptMagritte(self, aVisitor):
         aVisitor.visitContainer(self)
 
-    def inheritFrom(self, ancestor, updatedElements=None, removedElements=None):
-        if updatedElements is None:
-            updatedElements = []
-        if removedElements is None:
-            removedElements = []
+    def inheritFrom(self, ancestor, override=None, remove=None):
+        if override is None:
+            override = []
+        if remove is None:
+            remove = []
         self.ancestor = ancestor
-        update_dict = {elem.name: elem for elem in updatedElements}
+        override_dict = {elem.name: elem for elem in override}
         children = []
         for elem in ancestor.children:
-            if elem.name not in removedElements:
-                if elem.name in update_dict:
-                    children.append(update_dict.pop(elem.name))
+            if elem.name not in remove:
+                if elem.name in override_dict:
+                    children.append(override_dict.pop(elem.name))
                 else:
                     children.append(copy(elem))
-        children.extend(update_dict.values())
+        children.extend(override_dict.values())
         self.setChildren(children)

--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -37,6 +37,9 @@ class MAContainer(MADescription):
         except StopIteration:
             raise KeyError(name)
 
+    def __iter__(self):
+        return iter(self.children)
+
     def __copy__(self):
         clone = self.__class__()
         clone.__dict__.update(self.__dict__)

--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -93,6 +93,16 @@ class MAContainer(MADescription):
     def sa_defaultTableName(self):
         return self.name
 
+    @property
+    def ancestor(self):
+        try:
+            return self._ancestor
+        except AttributeError:
+            return None
+
+    @ancestor.setter
+    def ancestor(self, aDescription):
+        self._ancestor = aDescription
 
     @classmethod
     def withDescription(cls, aDescription):
@@ -179,4 +189,14 @@ class MAContainer(MADescription):
 
     def acceptMagritte(self, aVisitor):
         aVisitor.visitContainer(self)
-        
+
+    def inheritFrom(self, ancestor, updatedElements=None, removedElements=None):
+        if updatedElements is None:
+            updatedElements = []
+        if removedElements is None:
+            removedElements = []
+        self.ancestor = ancestor
+        update_dict = {elem.name: elem for elem in updatedElements}
+        children = [copy(elem) for elem in ancestor.children if elem.name not in removedElements]
+        children = [update_dict[elem.name] if elem.name in update_dict else elem for elem in children]
+        self.setChildren(children)

--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -32,6 +32,8 @@ class MAContainer(MADescription):
         return len(self._children)
 
     def __getitem__(self, name):
+        if not isinstance(name, str):
+            raise TypeError("Element name must be a string.")
         try:
             return self.detect(lambda item: item.name == name)
         except StopIteration:

--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -31,15 +31,17 @@ class MAContainer(MADescription):
     def __len__(self):
         return len(self._children)
 
-    def __getitem__(self, item):
-        return self._children[item]
+    def __getitem__(self, name):
+        try:
+            return self.detect(lambda item: item.name == name)
+        except StopIteration:
+            raise KeyError(name)
 
     def __copy__(self):
         clone = self.__class__()
         clone.__dict__.update(self.__dict__)
         clone.setChildren(copy(self.children))
         return clone
-
 
     @classmethod
     def defaultAccessor(cls):

--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -197,6 +197,12 @@ class MAContainer(MADescription):
             removedElements = []
         self.ancestor = ancestor
         update_dict = {elem.name: elem for elem in updatedElements}
-        children = [copy(elem) for elem in ancestor.children if elem.name not in removedElements]
-        children = [update_dict[elem.name] if elem.name in update_dict else elem for elem in children]
+        children = []
+        for elem in ancestor.children:
+            if elem.name not in removedElements:
+                if elem.name in update_dict:
+                    children.append(update_dict.pop(elem.name))
+                else:
+                    children.append(copy(elem))
+        children.extend(update_dict.values())
         self.setChildren(children)

--- a/Magritte/descriptions/MAContainer_selfdesc.py
+++ b/Magritte/descriptions/MAContainer_selfdesc.py
@@ -1,8 +1,11 @@
 from sys import intern
 
 from Magritte.accessors.MAAttrAccessor_class import MAAttrAccessor
+from Magritte.descriptions.MAContainer_class import MAContainer
 from Magritte.descriptions.MAToManyRelationDescription_class import MAToManyRelationDescription
 from Magritte.descriptions.MAElementDescription_class import MAElementDescription
+from Magritte.descriptions.MAToOneRelationDescription_class import MAToOneRelationDescription
+
 
 def magritteDescription(self, parentDescription):
     desc = parentDescription
@@ -16,5 +19,17 @@ def magritteDescription(self, parentDescription):
         reference = MAElementDescription().magritteDescription(),
         accessor = MAAttrAccessor('children')
     )
+
+    ancestor_desc = MAToOneRelationDescription(
+        name=intern('ancestor'),
+        label="Ancestor",
+        priority=300,
+        default=None,
+        classes=[MAContainer],
+        reference = desc,
+        accessor = MAAttrAccessor('ancestor')
+    )
+
+    desc += ancestor_desc
     
     return desc

--- a/Magritte/descriptions/MAContainer_selfdesc.py
+++ b/Magritte/descriptions/MAContainer_selfdesc.py
@@ -1,5 +1,6 @@
 from sys import intern
-from Magritte.accessors.MAIdentityAccessor_class import MAIdentityAccessor
+
+from Magritte.accessors.MAAttrAccessor_class import MAAttrAccessor
 from Magritte.descriptions.MAToManyRelationDescription_class import MAToManyRelationDescription
 from Magritte.descriptions.MAElementDescription_class import MAElementDescription
 
@@ -13,7 +14,7 @@ def magritteDescription(self, parentDescription):
         default=self.defaultCollection(),
         classes=[MAElementDescription],
         reference = MAElementDescription().magritteDescription(),
-        accessor = MAIdentityAccessor()
+        accessor = MAAttrAccessor('children')
     )
     
     return desc

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -169,6 +169,12 @@ class MAContainerTest(TestCase):
 
 class MAContainerInheritanceTest(TestCase):
 
+    @staticmethod
+    def _verify_children_by_labels(container, labels):
+        """Verify children of the container by their labels"""
+        # Labels will be used as unique identifiers for this test case
+        return {item.label for item in container.children} == set(labels)
+
     def setUp(self):
         self.ancestor = MAContainer(name='Ancestor')
         self.ancestor += MAStringDescription(name='string1', label='String 1')
@@ -176,59 +182,36 @@ class MAContainerInheritanceTest(TestCase):
         self.ancestor += MAStringDescription(name='string3', label='String 3')
         self.ancestor += MAStringDescription(label='String 4')
         self.ancestor += MAStringDescription(name='string5', label='String 5')
+        self.ancestor_labels = ['String 1', 'String 2', 'String 3', 'String 4', 'String 5']
 
     def test_inheritFrom_copy(self):
         descendant = MAContainer(name='Descendant')
         descendant.inheritFrom(self.ancestor)
         self.assertEqual(descendant.ancestor, self.ancestor)
-        self.assertEqual(len(descendant.children), len(self.ancestor.children))
-        for i in range(len(self.ancestor.children)):
-            self.assertEqual(self.ancestor.children[i].name, descendant.children[i].name)
-            self.assertEqual(self.ancestor.children[i].label, descendant.children[i].label)
+        self._verify_children_by_labels(descendant, self.ancestor_labels)
 
     def test_inheritFrom_update(self):
         descendant = MAContainer(name='Descendant')
         descendant.inheritFrom(self.ancestor, override=[MAStringDescription(name='string1', label='Updated String 1')])
         self.assertEqual(descendant.ancestor, self.ancestor)
-        self.assertEqual(len(descendant.children), len(self.ancestor.children))
-        for i in range(len(self.ancestor.children)):
-            if self.ancestor.children[i].name == 'string1':
-                self.assertEqual(descendant.children[i].label, 'Updated String 1')
-            else:
-                self.assertEqual(self.ancestor.children[i].name, descendant.children[i].name)
-                self.assertEqual(self.ancestor.children[i].label, descendant.children[i].label)
+        self._verify_children_by_labels(
+            descendant, ['Updated String 1', 'String 2', 'String 3', 'String 4', 'String 5']
+            )
 
     def test_inheritFrom_remove(self):
         descendant = MAContainer(name='Descendant')
         removed_elements = ['string1']
         descendant.inheritFrom(self.ancestor, remove=removed_elements)
         self.assertEqual(descendant.ancestor, self.ancestor)
-        self.assertEqual(len(descendant.children), len(self.ancestor.children) - len(removed_elements))
-        # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.ancestor.children)
-        d_child_iter = iter(descendant.children)
-        for a_child in a_child_iter:
-            if a_child.name in removed_elements:
-                continue
-            d_child = next(d_child_iter)
-            self.assertEqual(a_child.name, d_child.name)
-            self.assertEqual(a_child.label, d_child.label)
+        self._verify_children_by_labels(descendant, ['String 2', 'String 3', 'String 4', 'String 5'])
 
     def test_inheritFrom_insert(self):
         descendant = MAContainer(name='Descendant')
         descendant.inheritFrom(self.ancestor, override=[MAStringDescription(name='string6', label='String 6')])
         self.assertEqual(descendant.ancestor, self.ancestor)
-        self.assertEqual(len(descendant.children), len(self.ancestor.children) + 1)
-        # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.ancestor.children)
-        d_child_iter = iter(descendant.children)
-        for a_child in a_child_iter:
-            d_child = next(d_child_iter)
-            self.assertEqual(a_child.name, d_child.name)
-            self.assertEqual(a_child.label, d_child.label)
-        d_child = next(d_child_iter)
-        self.assertEqual(d_child.name, 'string6')
-        self.assertEqual(d_child.label, 'String 6')
+        self._verify_children_by_labels(
+            descendant, ['String 1', 'String 2', 'String 3', 'String 4', 'String 5', 'String 6']
+            )
 
     def test_inheritFrom_update_remove(self):
         descendant = MAContainer(name='Descendant')
@@ -239,19 +222,7 @@ class MAContainerInheritanceTest(TestCase):
             remove=removed_elements
             )
         self.assertEqual(descendant.ancestor, self.ancestor)
-        self.assertEqual(len(descendant.children), len(self.ancestor.children) - len(removed_elements))
-        # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.ancestor.children)
-        d_child_iter = iter(descendant.children)
-        for a_child in a_child_iter:
-            if a_child.name in removed_elements:
-                continue
-            d_child = next(d_child_iter)
-            self.assertEqual(a_child.name, d_child.name)
-            if a_child.name == 'string5':
-                self.assertEqual(d_child.label, 'Updated String 5')
-            else:
-                self.assertEqual(a_child.label, d_child.label)
+        self._verify_children_by_labels(descendant, ['Updated String 5', 'String 2', 'String 4'])
 
     def test_inheritFrom_update_remove_insert(self):
         descendant = MAContainer(name='Descendant')
@@ -265,19 +236,4 @@ class MAContainerInheritanceTest(TestCase):
             remove=removed_elements
             )
         self.assertEqual(descendant.ancestor, self.ancestor)
-        self.assertEqual(len(descendant.children), len(self.ancestor.children) - len(removed_elements) + 1)
-        # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.ancestor.children)
-        d_child_iter = iter(descendant.children)
-        for a_child in a_child_iter:
-            if a_child.name in removed_elements:
-                continue
-            d_child = next(d_child_iter)
-            self.assertEqual(a_child.name, d_child.name)
-            if a_child.name == 'string5':
-                self.assertEqual(d_child.label, 'Updated String 5')
-            else:
-                self.assertEqual(a_child.label, d_child.label)
-        d_child = next(d_child_iter)
-        self.assertEqual(d_child.name, 'string6')
-        self.assertEqual(d_child.label, 'String 6')
+        self._verify_children_by_labels(descendant, ['Updated String 5', 'String 2', 'String 4', 'String 6'])

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -170,43 +170,43 @@ class MAContainerTest(TestCase):
 class MAContainerInheritanceTest(TestCase):
 
     def setUp(self):
-        self.container1 = MAContainer(name='Ancestor')
-        self.container1 += MAStringDescription(name='string1', label='String 1')
-        self.container1 += MAStringDescription(label='String 2')
-        self.container1 += MAStringDescription(name='string3', label='String 3')
-        self.container1 += MAStringDescription(label='String 4')
-        self.container1 += MAStringDescription(name='string5', label='String 5')
+        self.ancestor = MAContainer(name='Ancestor')
+        self.ancestor += MAStringDescription(name='string1', label='String 1')
+        self.ancestor += MAStringDescription(label='String 2')
+        self.ancestor += MAStringDescription(name='string3', label='String 3')
+        self.ancestor += MAStringDescription(label='String 4')
+        self.ancestor += MAStringDescription(name='string5', label='String 5')
 
     def test_inheritFrom_copy(self):
-        container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(self.container1)
-        self.assertEqual(container2.ancestor, self.container1)
-        self.assertEqual(len(container2.children), len(self.container1.children))
-        for i in range(len(self.container1.children)):
-            self.assertEqual(self.container1.children[i].name, container2.children[i].name)
-            self.assertEqual(self.container1.children[i].label, container2.children[i].label)
+        descendant = MAContainer(name='Descendant')
+        descendant.inheritFrom(self.ancestor)
+        self.assertEqual(descendant.ancestor, self.ancestor)
+        self.assertEqual(len(descendant.children), len(self.ancestor.children))
+        for i in range(len(self.ancestor.children)):
+            self.assertEqual(self.ancestor.children[i].name, descendant.children[i].name)
+            self.assertEqual(self.ancestor.children[i].label, descendant.children[i].label)
 
     def test_inheritFrom_update(self):
-        container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(self.container1, override=[MAStringDescription(name='string1', label='Updated String 1')])
-        self.assertEqual(container2.ancestor, self.container1)
-        self.assertEqual(len(container2.children), len(self.container1.children))
-        for i in range(len(self.container1.children)):
-            if self.container1.children[i].name == 'string1':
-                self.assertEqual(container2.children[i].label, 'Updated String 1')
+        descendant = MAContainer(name='Descendant')
+        descendant.inheritFrom(self.ancestor, override=[MAStringDescription(name='string1', label='Updated String 1')])
+        self.assertEqual(descendant.ancestor, self.ancestor)
+        self.assertEqual(len(descendant.children), len(self.ancestor.children))
+        for i in range(len(self.ancestor.children)):
+            if self.ancestor.children[i].name == 'string1':
+                self.assertEqual(descendant.children[i].label, 'Updated String 1')
             else:
-                self.assertEqual(self.container1.children[i].name, container2.children[i].name)
-                self.assertEqual(self.container1.children[i].label, container2.children[i].label)
+                self.assertEqual(self.ancestor.children[i].name, descendant.children[i].name)
+                self.assertEqual(self.ancestor.children[i].label, descendant.children[i].label)
 
     def test_inheritFrom_remove(self):
-        container2 = MAContainer(name='Descendant')
+        descendant = MAContainer(name='Descendant')
         removed_elements = ['string1']
-        container2.inheritFrom(self.container1, remove=removed_elements)
-        self.assertEqual(container2.ancestor, self.container1)
-        self.assertEqual(len(container2.children), len(self.container1.children) - len(removed_elements))
+        descendant.inheritFrom(self.ancestor, remove=removed_elements)
+        self.assertEqual(descendant.ancestor, self.ancestor)
+        self.assertEqual(len(descendant.children), len(self.ancestor.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.container1.children)
-        d_child_iter = iter(container2.children)
+        a_child_iter = iter(self.ancestor.children)
+        d_child_iter = iter(descendant.children)
         for a_child in a_child_iter:
             if a_child.name in removed_elements:
                 continue
@@ -215,13 +215,13 @@ class MAContainerInheritanceTest(TestCase):
             self.assertEqual(a_child.label, d_child.label)
 
     def test_inheritFrom_insert(self):
-        container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(self.container1, override=[MAStringDescription(name='string6', label='String 6')])
-        self.assertEqual(container2.ancestor, self.container1)
-        self.assertEqual(len(container2.children), len(self.container1.children) + 1)
+        descendant = MAContainer(name='Descendant')
+        descendant.inheritFrom(self.ancestor, override=[MAStringDescription(name='string6', label='String 6')])
+        self.assertEqual(descendant.ancestor, self.ancestor)
+        self.assertEqual(len(descendant.children), len(self.ancestor.children) + 1)
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.container1.children)
-        d_child_iter = iter(container2.children)
+        a_child_iter = iter(self.ancestor.children)
+        d_child_iter = iter(descendant.children)
         for a_child in a_child_iter:
             d_child = next(d_child_iter)
             self.assertEqual(a_child.name, d_child.name)
@@ -231,18 +231,18 @@ class MAContainerInheritanceTest(TestCase):
         self.assertEqual(d_child.label, 'String 6')
 
     def test_inheritFrom_update_remove(self):
-        container2 = MAContainer(name='Descendant')
+        descendant = MAContainer(name='Descendant')
         removed_elements = ['string1', 'string3']
-        container2.inheritFrom(
-            self.container1,
+        descendant.inheritFrom(
+            self.ancestor,
             override=[MAStringDescription(name='string5', label='Updated String 5')],
             remove=removed_elements
             )
-        self.assertEqual(container2.ancestor, self.container1)
-        self.assertEqual(len(container2.children), len(self.container1.children) - len(removed_elements))
+        self.assertEqual(descendant.ancestor, self.ancestor)
+        self.assertEqual(len(descendant.children), len(self.ancestor.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.container1.children)
-        d_child_iter = iter(container2.children)
+        a_child_iter = iter(self.ancestor.children)
+        d_child_iter = iter(descendant.children)
         for a_child in a_child_iter:
             if a_child.name in removed_elements:
                 continue
@@ -254,21 +254,21 @@ class MAContainerInheritanceTest(TestCase):
                 self.assertEqual(a_child.label, d_child.label)
 
     def test_inheritFrom_update_remove_insert(self):
-        container2 = MAContainer(name='Descendant')
+        descendant = MAContainer(name='Descendant')
         removed_elements = ['string1', 'string3']
-        container2.inheritFrom(
-            self.container1,
+        descendant.inheritFrom(
+            self.ancestor,
             override=[
                 MAStringDescription(name='string5', label='Updated String 5'),
                 MAStringDescription(name='string6', label='String 6')
                 ],
             remove=removed_elements
             )
-        self.assertEqual(container2.ancestor, self.container1)
-        self.assertEqual(len(container2.children), len(self.container1.children) - len(removed_elements) + 1)
+        self.assertEqual(descendant.ancestor, self.ancestor)
+        self.assertEqual(len(descendant.children), len(self.ancestor.children) - len(removed_elements) + 1)
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(self.container1.children)
-        d_child_iter = iter(container2.children)
+        a_child_iter = iter(self.ancestor.children)
+        d_child_iter = iter(descendant.children)
         for a_child in a_child_iter:
             if a_child.name in removed_elements:
                 continue

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -167,50 +167,45 @@ class MAContainerTest(TestCase):
         self.inst1.setChildren([1, 2, 3, 4])
         self.assertEqual([item for item in self.inst1], [1, 2, 3, 4])
 
+class MAContainerInheritanceTest(TestCase):
+
+    def setUp(self):
+        self.container1 = MAContainer(name='Ancestor')
+        self.container1 += MAStringDescription(name='string1', label='String 1')
+        self.container1 += MAStringDescription(label='String 2')
+        self.container1 += MAStringDescription(name='string3', label='String 3')
+        self.container1 += MAStringDescription(label='String 4')
+        self.container1 += MAStringDescription(name='string5', label='String 5')
+
     def test_inheritFrom_copy(self):
-        container1 = MAContainer(name='Ancestor')
-        container1 += MAStringDescription(name='string1', label='String 1')
-        container1 += MAStringDescription(label='String 2')
-        container1 += MAStringDescription(name='string3', label='String 3')
-        container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(container1)
-        self.assertEqual(container2.ancestor, container1)
-        self.assertEqual(len(container2.children), len(container1.children))
-        for i in range(len(container1.children)):
-            self.assertEqual(container1.children[i].name, container2.children[i].name)
-            self.assertEqual(container1.children[i].label, container2.children[i].label)
+        container2.inheritFrom(self.container1)
+        self.assertEqual(container2.ancestor, self.container1)
+        self.assertEqual(len(container2.children), len(self.container1.children))
+        for i in range(len(self.container1.children)):
+            self.assertEqual(self.container1.children[i].name, container2.children[i].name)
+            self.assertEqual(self.container1.children[i].label, container2.children[i].label)
 
     def test_inheritFrom_update(self):
-        container1 = MAContainer(name='Ancestor')
-        container1 += MAStringDescription(name='string1', label='String 1')
-        container1 += MAStringDescription(label='String 2')
-        container1 += MAStringDescription(name='string3', label='String 3')
-        container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(container1, override=[MAStringDescription(name='string1', label='Updated String 1')])
-        self.assertEqual(container2.ancestor, container1)
-        self.assertEqual(len(container2.children), len(container1.children))
-        for i in range(len(container1.children)):
-            if container1.children[i].name == 'string1':
+        container2.inheritFrom(self.container1, override=[MAStringDescription(name='string1', label='Updated String 1')])
+        self.assertEqual(container2.ancestor, self.container1)
+        self.assertEqual(len(container2.children), len(self.container1.children))
+        for i in range(len(self.container1.children)):
+            if self.container1.children[i].name == 'string1':
                 self.assertEqual(container2.children[i].label, 'Updated String 1')
             else:
-                self.assertEqual(container1.children[i].name, container2.children[i].name)
-                self.assertEqual(container1.children[i].label, container2.children[i].label)
+                self.assertEqual(self.container1.children[i].name, container2.children[i].name)
+                self.assertEqual(self.container1.children[i].label, container2.children[i].label)
 
     def test_inheritFrom_remove(self):
-        container1 = MAContainer(name='Ancestor')
-        container1 += MAStringDescription(name='string1', label='String 1')
-        container1 += MAStringDescription(label='String 2')
-        container1 += MAStringDescription(name='string3', label='String 3')
-        container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
         removed_elements = ['string1']
-        container2.inheritFrom(container1, remove=removed_elements)
-        self.assertEqual(container2.ancestor, container1)
-        self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
+        container2.inheritFrom(self.container1, remove=removed_elements)
+        self.assertEqual(container2.ancestor, self.container1)
+        self.assertEqual(len(container2.children), len(self.container1.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(container1.children)
+        a_child_iter = iter(self.container1.children)
         d_child_iter = iter(container2.children)
         for a_child in a_child_iter:
             if a_child.name in removed_elements:
@@ -220,44 +215,33 @@ class MAContainerTest(TestCase):
             self.assertEqual(a_child.label, d_child.label)
 
     def test_inheritFrom_insert(self):
-        container1 = MAContainer(name='Ancestor')
-        container1 += MAStringDescription(name='string1', label='String 1')
-        container1 += MAStringDescription(label='String 2')
-        container1 += MAStringDescription(name='string3', label='String 3')
-        container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(container1, override=[MAStringDescription(name='string5', label='String 5')])
-        self.assertEqual(container2.ancestor, container1)
-        self.assertEqual(len(container2.children), len(container1.children) + 1)
+        container2.inheritFrom(self.container1, override=[MAStringDescription(name='string6', label='String 6')])
+        self.assertEqual(container2.ancestor, self.container1)
+        self.assertEqual(len(container2.children), len(self.container1.children) + 1)
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(container1.children)
+        a_child_iter = iter(self.container1.children)
         d_child_iter = iter(container2.children)
         for a_child in a_child_iter:
             d_child = next(d_child_iter)
             self.assertEqual(a_child.name, d_child.name)
             self.assertEqual(a_child.label, d_child.label)
         d_child = next(d_child_iter)
-        self.assertEqual(d_child.name, 'string5')
-        self.assertEqual(d_child.label, 'String 5')
+        self.assertEqual(d_child.name, 'string6')
+        self.assertEqual(d_child.label, 'String 6')
 
     def test_inheritFrom_update_remove(self):
-        container1 = MAContainer(name='Ancestor')
-        container1 += MAStringDescription(name='string1', label='String 1')
-        container1 += MAStringDescription(label='String 2')
-        container1 += MAStringDescription(name='string3', label='String 3')
-        container1 += MAStringDescription(label='String 4')
-        container1 += MAStringDescription(name='string5', label='String 5')
         container2 = MAContainer(name='Descendant')
         removed_elements = ['string1', 'string3']
         container2.inheritFrom(
-            container1,
+            self.container1,
             override=[MAStringDescription(name='string5', label='Updated String 5')],
             remove=removed_elements
             )
-        self.assertEqual(container2.ancestor, container1)
-        self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
+        self.assertEqual(container2.ancestor, self.container1)
+        self.assertEqual(len(container2.children), len(self.container1.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(container1.children)
+        a_child_iter = iter(self.container1.children)
         d_child_iter = iter(container2.children)
         for a_child in a_child_iter:
             if a_child.name in removed_elements:
@@ -270,26 +254,20 @@ class MAContainerTest(TestCase):
                 self.assertEqual(a_child.label, d_child.label)
 
     def test_inheritFrom_update_remove_insert(self):
-        container1 = MAContainer(name='Ancestor')
-        container1 += MAStringDescription(name='string1', label='String 1')
-        container1 += MAStringDescription(label='String 2')
-        container1 += MAStringDescription(name='string3', label='String 3')
-        container1 += MAStringDescription(label='String 4')
-        container1 += MAStringDescription(name='string5', label='String 5')
         container2 = MAContainer(name='Descendant')
         removed_elements = ['string1', 'string3']
         container2.inheritFrom(
-            container1,
+            self.container1,
             override=[
                 MAStringDescription(name='string5', label='Updated String 5'),
                 MAStringDescription(name='string6', label='String 6')
                 ],
             remove=removed_elements
             )
-        self.assertEqual(container2.ancestor, container1)
-        self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements) + 1)
+        self.assertEqual(container2.ancestor, self.container1)
+        self.assertEqual(len(container2.children), len(self.container1.children) - len(removed_elements) + 1)
         # parallel iteration over two lists skipping removed item
-        a_child_iter = iter(container1.children)
+        a_child_iter = iter(self.container1.children)
         d_child_iter = iter(container2.children)
         for a_child in a_child_iter:
             if a_child.name in removed_elements:

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -29,11 +29,15 @@ class MAContainerTest(TestCase):
         self.assertEqual(len(self.inst1), 4)
 
     def test_getitem(self):
-        self.inst1 += 'exm1'
-        self.inst1 += 'exm2'
-        self.inst1 += 'exm3'
-        self.inst1 += 'exm4'
-        self.assertEqual(self.inst1[0], 'exm1')
+        class SmthWName:
+            def __init__(self, name):
+                self.name = name
+        elements = [SmthWName('exm1'), SmthWName('exm2'), SmthWName('exm3'), SmthWName('exm4')]
+        self.inst1 += elements[0]
+        self.inst1 += elements[1]
+        self.inst1 += elements[2]
+        self.inst1 += elements[3]
+        self.assertEqual(self.inst1['exm2'], elements[1])
 
     def test_copy(self):
         exm = copy(self.inst1)
@@ -91,8 +95,8 @@ class MAContainerTest(TestCase):
 
     def test_get(self):
         self.inst1.setChildren([1, 2, 3, 4])
-        self.assertEqual(self.inst1[2] if 2 < len(self.inst1) else 'index > len', 3)
-        self.assertEqual(self.inst1[7] if 7 < len(self.inst1) else 'index > len', 'index > len')
+        self.assertEqual(self.inst1.children[2] if 2 < len(self.inst1) else 'index > len', 3)
+        self.assertEqual(self.inst1.children[7] if 7 < len(self.inst1) else 'index > len', 'index > len')
 
     def test_allSatisfy(self):
         self.inst1.setChildren([1, 2, 3, 4])

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -3,6 +3,7 @@ from copy import copy
 
 from Magritte.descriptions.MAContainer_class import MAContainer
 from Magritte.accessors.MAIdentityAccessor_class import MAIdentityAccessor
+from Magritte.descriptions.MAStringDescription_class import MAStringDescription
 
 
 class MAContainerTest(TestCase):
@@ -29,15 +30,16 @@ class MAContainerTest(TestCase):
         self.assertEqual(len(self.inst1), 4)
 
     def test_getitem(self):
-        class SmthWName:
-            def __init__(self, name):
-                self.name = name
-        elements = [SmthWName('exm1'), SmthWName('exm2'), SmthWName('exm3'), SmthWName('exm4')]
-        self.inst1 += elements[0]
-        self.inst1 += elements[1]
-        self.inst1 += elements[2]
-        self.inst1 += elements[3]
-        self.assertEqual(self.inst1['exm2'], elements[1])
+        desc = MAContainer()
+        desc += MAStringDescription(name="first", label="First Field")
+        desc += MAStringDescription(label="nameless #2")
+        desc += MAStringDescription(name="second", label="Second Field")
+        desc += MAStringDescription(label="nameless #1")
+
+        self.assertEqual(desc["first"].label, "First Field")
+        self.assertEqual(desc["second"].label, "Second Field")
+        with self.assertRaises(KeyError):
+            desc["third"]
 
     def test_copy(self):
         exm = copy(self.inst1)

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -169,6 +169,7 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
         container2.inheritFrom(container1)
+        self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children))
         for i in range(len(container1.children)):
             self.assertEqual(container1.children[i].name, container2.children[i].name)
@@ -182,6 +183,7 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
         container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string1', label='Updated String 1')])
+        self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children))
         for i in range(len(container1.children)):
             if container1.children[i].name == 'string1':
@@ -199,6 +201,7 @@ class MAContainerTest(TestCase):
         container2 = MAContainer(name='Descendant')
         removed_elements = ['string1']
         container2.inheritFrom(container1, removedElements=removed_elements)
+        self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
         a_child_iter = iter(container1.children)
@@ -218,6 +221,7 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
         container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string5', label='String 5')])
+        self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) + 1)
         # parallel iteration over two lists skipping removed item
         a_child_iter = iter(container1.children)
@@ -239,8 +243,12 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(name='string5', label='String 5')
         container2 = MAContainer(name='Descendant')
         removed_elements = ['string1', 'string3']
-        container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string5', label='Updated String 5')],
-                               removedElements=removed_elements)
+        container2.inheritFrom(
+            container1,
+            updatedElements=[MAStringDescription(name='string5', label='Updated String 5')],
+            removedElements=removed_elements
+            )
+        self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
         a_child_iter = iter(container1.children)
@@ -272,6 +280,7 @@ class MAContainerTest(TestCase):
                 ],
             removedElements=removed_elements
             )
+        self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements) + 1)
         # parallel iteration over two lists skipping removed item
         a_child_iter = iter(container1.children)

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -160,3 +160,77 @@ class MAContainerTest(TestCase):
     def test_keysAndValuesDo(self):
         self.inst1.setChildren([1, 2, 3, 4])
         self.assertEqual(self.inst1.keysAndValuesDo(self.block2), None)
+
+    def test_inheritFrom_copy(self):
+        container1 = MAContainer(name='Ancestor')
+        container1 += MAStringDescription(name='string1', label='String 1')
+        container1 += MAStringDescription(label='String 2')
+        container1 += MAStringDescription(name='string3', label='String 3')
+        container1 += MAStringDescription(label='String 4')
+        container2 = MAContainer(name='Descendant')
+        container2.inheritFrom(container1)
+        self.assertEqual(len(container2.children), len(container1.children))
+        for i in range(len(container1.children)):
+            self.assertEqual(container1.children[i].name, container2.children[i].name)
+            self.assertEqual(container1.children[i].label, container2.children[i].label)
+
+    def test_inheritFrom_update(self):
+        container1 = MAContainer(name='Ancestor')
+        container1 += MAStringDescription(name='string1', label='String 1')
+        container1 += MAStringDescription(label='String 2')
+        container1 += MAStringDescription(name='string3', label='String 3')
+        container1 += MAStringDescription(label='String 4')
+        container2 = MAContainer(name='Descendant')
+        container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string1', label='Updated String 1')])
+        self.assertEqual(len(container2.children), len(container1.children))
+        for i in range(len(container1.children)):
+            if container1.children[i].name == 'string1':
+                self.assertEqual(container2.children[i].label, 'Updated String 1')
+            else:
+                self.assertEqual(container1.children[i].name, container2.children[i].name)
+                self.assertEqual(container1.children[i].label, container2.children[i].label)
+
+    def test_inheritFrom_remove(self):
+        container1 = MAContainer(name='Ancestor')
+        container1 += MAStringDescription(name='string1', label='String 1')
+        container1 += MAStringDescription(label='String 2')
+        container1 += MAStringDescription(name='string3', label='String 3')
+        container1 += MAStringDescription(label='String 4')
+        container2 = MAContainer(name='Descendant')
+        removed_elements = ['string1']
+        container2.inheritFrom(container1, removedElements=removed_elements)
+        self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
+        # parallel iteration over two lists skipping removed item
+        a_child_iter = iter(container1.children)
+        d_child_iter = iter(container2.children)
+        for a_child in a_child_iter:
+            if a_child.name in removed_elements:
+                continue
+            d_child = next(d_child_iter)
+            self.assertEqual(a_child.name, d_child.name)
+            self.assertEqual(a_child.label, d_child.label)
+
+    def test_inheritFrom_update_remove(self):
+        container1 = MAContainer(name='Ancestor')
+        container1 += MAStringDescription(name='string1', label='String 1')
+        container1 += MAStringDescription(label='String 2')
+        container1 += MAStringDescription(name='string3', label='String 3')
+        container1 += MAStringDescription(label='String 4')
+        container1 += MAStringDescription(name='string5', label='String 5')
+        container2 = MAContainer(name='Descendant')
+        removed_elements = ['string1', 'string3']
+        container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string5', label='Updated String 5')],
+                               removedElements=removed_elements)
+        self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
+        # parallel iteration over two lists skipping removed item
+        a_child_iter = iter(container1.children)
+        d_child_iter = iter(container2.children)
+        for a_child in a_child_iter:
+            if a_child.name in removed_elements:
+                continue
+            d_child = next(d_child_iter)
+            self.assertEqual(a_child.name, d_child.name)
+            if a_child.name == 'string5':
+                self.assertEqual(d_child.label, 'Updated String 5')
+            else:
+                self.assertEqual(a_child.label, d_child.label)

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -161,6 +161,10 @@ class MAContainerTest(TestCase):
         self.inst1.setChildren([1, 2, 3, 4])
         self.assertEqual(self.inst1.keysAndValuesDo(self.block2), None)
 
+    def test_iter(self):
+        self.inst1.setChildren([1, 2, 3, 4])
+        self.assertEqual([item for item in self.inst1], [1, 2, 3, 4])
+
     def test_inheritFrom_copy(self):
         container1 = MAContainer(name='Ancestor')
         container1 += MAStringDescription(name='string1', label='String 1')

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -38,8 +38,10 @@ class MAContainerTest(TestCase):
 
         self.assertEqual(desc["first"].label, "First Field")
         self.assertEqual(desc["second"].label, "Second Field")
+        with self.assertRaises(TypeError):
+            _ = desc[0]
         with self.assertRaises(KeyError):
-            desc["third"]
+            _ = desc["third"]
 
     def test_copy(self):
         exm = copy(self.inst1)

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -188,7 +188,7 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(name='string3', label='String 3')
         container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string1', label='Updated String 1')])
+        container2.inheritFrom(container1, override=[MAStringDescription(name='string1', label='Updated String 1')])
         self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children))
         for i in range(len(container1.children)):
@@ -206,7 +206,7 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
         removed_elements = ['string1']
-        container2.inheritFrom(container1, removedElements=removed_elements)
+        container2.inheritFrom(container1, remove=removed_elements)
         self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
         # parallel iteration over two lists skipping removed item
@@ -226,7 +226,7 @@ class MAContainerTest(TestCase):
         container1 += MAStringDescription(name='string3', label='String 3')
         container1 += MAStringDescription(label='String 4')
         container2 = MAContainer(name='Descendant')
-        container2.inheritFrom(container1, updatedElements=[MAStringDescription(name='string5', label='String 5')])
+        container2.inheritFrom(container1, override=[MAStringDescription(name='string5', label='String 5')])
         self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) + 1)
         # parallel iteration over two lists skipping removed item
@@ -251,8 +251,8 @@ class MAContainerTest(TestCase):
         removed_elements = ['string1', 'string3']
         container2.inheritFrom(
             container1,
-            updatedElements=[MAStringDescription(name='string5', label='Updated String 5')],
-            removedElements=removed_elements
+            override=[MAStringDescription(name='string5', label='Updated String 5')],
+            remove=removed_elements
             )
         self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements))
@@ -280,11 +280,11 @@ class MAContainerTest(TestCase):
         removed_elements = ['string1', 'string3']
         container2.inheritFrom(
             container1,
-            updatedElements=[
+            override=[
                 MAStringDescription(name='string5', label='Updated String 5'),
                 MAStringDescription(name='string6', label='String 6')
                 ],
-            removedElements=removed_elements
+            remove=removed_elements
             )
         self.assertEqual(container2.ancestor, container1)
         self.assertEqual(len(container2.children), len(container1.children) - len(removed_elements) + 1)

--- a/Magritte/visitors/tests/selfdesc_test.py
+++ b/Magritte/visitors/tests/selfdesc_test.py
@@ -48,7 +48,7 @@ class TestVisualizerVisitor(MAVisitor):
     def visitContainer(self, description):
         if not self.json:
             self.json = {}
-            self.visitAll(description)
+            self.visitAll(description.children)
         else:
             raise Exception("Shouldn't reach visitContainer with nonempty self.json")
 
@@ -146,7 +146,7 @@ class MagritteSelfDescriptionTest(AbstractTestForAllDescriptions):
             with self.subTest(desc):
                 description = desc()
                 metadescription = description.magritteDescription()
-                for desc_field_desc in metadescription:
+                for desc_field_desc in metadescription.children:
                     val = description.readUsing(desc_field_desc)
                     #print(f"{desc.__name__}.{desc_field_desc.name} = `{val}`")
                     if(desc_field_desc.isRequired()):

--- a/Magritte/visitors/tests/selfdesc_test.py
+++ b/Magritte/visitors/tests/selfdesc_test.py
@@ -48,7 +48,7 @@ class TestVisualizerVisitor(MAVisitor):
     def visitContainer(self, description):
         if not self.json:
             self.json = {}
-            self.visitAll(description.children)
+            self.visitAll(description)
         else:
             raise Exception("Shouldn't reach visitContainer with nonempty self.json")
 
@@ -146,7 +146,7 @@ class MagritteSelfDescriptionTest(AbstractTestForAllDescriptions):
             with self.subTest(desc):
                 description = desc()
                 metadescription = description.magritteDescription()
-                for desc_field_desc in metadescription.children:
+                for desc_field_desc in metadescription:
                     val = description.readUsing(desc_field_desc)
                     #print(f"{desc.__name__}.{desc_field_desc.name} = `{val}`")
                     if(desc_field_desc.isRequired()):


### PR DESCRIPTION
Initial `MAContainer` inheritance implemented via `inheritFrom()` method.
Minimal tests added. Tests assume elements' order is preserved during inheritance. Probably too strict. Other option would require all elements have names or valid `__eq__` implementation for `MAElementDescription`.
Todo: update selfDesc and respective tests.