### PR TITLE
sa_shouldGeneratePrimaryKey

### DIFF
--- a/Magritte/descriptions/MAContainer_class.py
+++ b/Magritte/descriptions/MAContainer_class.py
@@ -96,6 +96,20 @@ class MAContainer(MADescription):
         return self.name
 
     @property
+    def sa_shouldGeneratePrimaryKey(self):
+        try:
+            return self._sa_shouldGeneratePrimaryKey
+        except AttributeError:
+            return self.sa_defaultShouldGeneratePrimaryKey()
+
+    @sa_shouldGeneratePrimaryKey.setter
+    def sa_shouldGeneratePrimaryKey(self, aBool):
+        self._sa_shouldGeneratePrimaryKey = aBool
+
+    def sa_defaultShouldGeneratePrimaryKey(self):
+        return False
+
+    @property
     def ancestor(self):
         try:
             return self._ancestor

--- a/Magritte/descriptions/MAContainer_selfdesc.py
+++ b/Magritte/descriptions/MAContainer_selfdesc.py
@@ -1,5 +1,6 @@
 from sys import intern
 
+from Magritte.descriptions.MABooleanDescription_class import MABooleanDescription
 from Magritte.accessors.MAAttrAccessor_class import MAAttrAccessor
 from Magritte.descriptions.MAContainer_class import MAContainer
 from Magritte.descriptions.MAToManyRelationDescription_class import MAToManyRelationDescription
@@ -31,5 +32,14 @@ def magritteDescription(self, parentDescription):
     )
 
     desc += ancestor_desc
+
+    desc += MABooleanDescription(
+        name=intern('sa_shouldGeneratePrimaryKey'),
+        label="DB-generated Primary Key",
+        comment="If True, the database will generate a primary key for this object. If False, the primary key must be set manually.",
+        priority=1000,
+        default=self.sa_defaultShouldGeneratePrimaryKey(),
+        accessor=MAAttrAccessor('sa_shouldGeneratePrimaryKey')
+    )
     
     return desc

--- a/Magritte/descriptions/tests/MAContainer_test.py
+++ b/Magritte/descriptions/tests/MAContainer_test.py
@@ -50,6 +50,19 @@ class MAContainerTest(TestCase):
     def test_defaultAccessor(self):
         self.assertEqual(isinstance(MAContainer.defaultAccessor(), MAIdentityAccessor), True)
 
+    def test_sa_shouldGeneratePrimaryKey_default(self):
+        self.assertFalse(self.inst1.sa_shouldGeneratePrimaryKey)
+
+    def test_sa_shouldGeneratePrimaryKey_read_write(self):
+        self.inst1.sa_shouldGeneratePrimaryKey = True
+        self.assertTrue(self.inst1.sa_shouldGeneratePrimaryKey)
+        self.inst1.sa_shouldGeneratePrimaryKey = False
+        self.assertFalse(self.inst1.sa_shouldGeneratePrimaryKey)
+
+    def test_sa_shouldGeneratePrimaryKey_constructor(self):
+        desc = MAContainer(sa_shouldGeneratePrimaryKey=True)
+        self.assertTrue(desc.sa_shouldGeneratePrimaryKey)
+
     def test_getChildren(self):
         self.assertEqual(self.inst1.children, [])
 

--- a/MagritteSQLAlchemy/imperative/fieldsmapper.py
+++ b/MagritteSQLAlchemy/imperative/fieldsmapper.py
@@ -1,5 +1,5 @@
 import logging
-from sqlalchemy import Table, Column, Integer, String, Date, Boolean, DateTime, Text, Float
+from sqlalchemy import Table, Column, Integer, String, Date, Boolean, DateTime, Text, Float, Identity
 
 from Magritte.descriptions.MAContainer_class import MAContainer
 from Magritte.visitors.MAVisitor_class import MAVisitor
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 class FieldsMapper(MAVisitor):
     def __init__(self):
         self.table = None
+        # Needed to access container-level description flags while visiting child fields.
+        self._container_description = None
 
     def map(self, description: MAContainer, table: Table) -> Table:
         self.table = table
@@ -22,17 +24,49 @@ class FieldsMapper(MAVisitor):
 
     def visitContainer(self, description):
         logger.debug(f'visitContainer {description.name}')
-        self.visitAll(filter(lambda x: x.sa_storable, description.children))
+        previous_container = self._container_description
+        self._container_description = description
+        try:
+            self.visitAll(filter(lambda x: x.sa_storable, description.children))
+            if description.sa_shouldGeneratePrimaryKey and len(self.table.primary_key) > 1:
+                logger.warning(
+                    "Table %s has more than one (%d) primary key fields marked for DB generation",
+                    description.name,
+                    len(self.table.primary_key),
+                )
+        finally:
+            self._container_description = previous_container
+
+
+    def _raise_if_primary_key_generation_requested(self, description):
+        if (
+            self._container_description is not None
+            and self._container_description.sa_shouldGeneratePrimaryKey
+            and description.sa_isPrimaryKey
+        ):
+            raise ValueError(
+                f"Table {self.table.name} cannot auto-generate primary key field(s): "
+                f"{description.name} ({description.type})."
+            )
 
     def visitIntDescription(self, description):
         logger.debug(f'visitIntDescription {description.name}')
+        if (
+            self._container_description is not None
+            and self._container_description.sa_shouldGeneratePrimaryKey
+            and description.sa_isPrimaryKey
+        ):
+            column_args = [Identity()]
+        else:
+            column_args = []
         self.table.append_column(Column(
-            description.sa_fieldName, Integer,
+            description.sa_fieldName, Integer, *column_args,
             primary_key=description.sa_isPrimaryKey, nullable=(not description.required)
             ))
 
     def visitStringDescription(self, description):
         logger.debug(f'visitStringDescription {description.name}')
+        self._raise_if_primary_key_generation_requested(description)
         self.table.append_column(Column(
             description.sa_fieldName, Text,
             primary_key=description.sa_isPrimaryKey, nullable=(not description.required)
@@ -40,6 +74,7 @@ class FieldsMapper(MAVisitor):
 
     def visitFloatDescription(self, description):
         logger.debug(f'visitFloatDescription {description.name}')
+        self._raise_if_primary_key_generation_requested(description)
         self.table.append_column(Column(
             description.sa_fieldName, Float,
             primary_key=description.sa_isPrimaryKey, nullable=(not description.required)
@@ -47,6 +82,7 @@ class FieldsMapper(MAVisitor):
 
     def visitDateDescription(self, description):
         logger.debug(f'visitDateDescription {description.name}')
+        self._raise_if_primary_key_generation_requested(description)
         self.table.append_column(Column(
             description.sa_fieldName, Date,
             primary_key=description.sa_isPrimaryKey, nullable=(not description.required)
@@ -54,6 +90,7 @@ class FieldsMapper(MAVisitor):
 
     def visitDateAndTimeDescription(self, description):
         logger.debug(f'visitDateAndTimeDescription {description.name}')
+        self._raise_if_primary_key_generation_requested(description)
         self.table.append_column(Column(
             description.sa_fieldName, DateTime(timezone=True),
             primary_key=description.sa_isPrimaryKey, nullable=(not description.required)
@@ -61,6 +98,7 @@ class FieldsMapper(MAVisitor):
 
     def visitBooleanDescription(self, description):
         logger.debug(f'visitBooleanDescription {description.name}')
+        self._raise_if_primary_key_generation_requested(description)
         self.table.append_column(Column(
             description.sa_fieldName, Boolean,
             primary_key=description.sa_isPrimaryKey, nullable=(not description.required)

--- a/MagritteSQLAlchemy/imperative/fieldsmapper.py
+++ b/MagritteSQLAlchemy/imperative/fieldsmapper.py
@@ -34,6 +34,8 @@ class FieldsMapper(MAVisitor):
                     description.name,
                     len(self.table.primary_key),
                 )
+            if len(self.table.primary_key) == 0:
+                raise ValueError(f'Table {self.table.name} does not have primary keys')
         finally:
             self._container_description = previous_container
 

--- a/MagritteSQLAlchemy/imperative/registrator.py
+++ b/MagritteSQLAlchemy/imperative/registrator.py
@@ -42,9 +42,6 @@ def register(
         # map scalar fields
         fields_mapper.map(descriptor, table)
 
-        if len(table.primary_key) == 0:
-            raise ValueError(f'Table {table.name} does not have primary keys')
-
         logger.debug(f'Table columns for {descriptor.name}: {table.c}')
         logger.debug(f' ================= > Created table for {descriptor.name} ...')
 

--- a/MagritteSQLAlchemy/imperative/tests/registrator_test.py
+++ b/MagritteSQLAlchemy/imperative/tests/registrator_test.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from unittest.mock import patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -9,7 +10,10 @@ from unittest import TestCase
 from sqlalchemy.sql.ddl import CreateSchema
 
 from Magritte.descriptions.MAContainer_class import MAContainer
+from Magritte.descriptions.MABooleanDescription_class import MABooleanDescription
+from Magritte.descriptions.MAIntDescription_class import MAIntDescription
 from Magritte.descriptions.MAStringDescription_class import MAStringDescription
+from Magritte.descriptions.MASingleOptionDescription_class import MASingleOptionDescription
 from Magritte.model_for_tests.ModelDescriptor_test import TestModelDescriptorProvider
 from Magritte.model_for_tests.EnvironmentProvider_test import TestEnvironmentProvider
 from Magritte.model_for_tests import (Organization, Host, User, Port, Account, SubscriptionPlan, SoftwarePackage, )
@@ -43,6 +47,18 @@ class NoPkModel:
     pass
 
 
+def _make_model_class(name):
+    return type(name, (), {})
+
+
+def _make_descriptor(name, kind, children, should_generate_pk=True):
+    descriptor = MAContainer(name=name)
+    descriptor.kind = kind
+    descriptor.sa_shouldGeneratePrimaryKey = should_generate_pk
+    descriptor.setChildren(children)
+    return descriptor
+
+
 class TestRegistratorPrimaryKeyValidation(TestCase):
 
     def test_register_raises_when_no_primary_key_is_defined(self):
@@ -57,6 +73,99 @@ class TestRegistratorPrimaryKeyValidation(TestCase):
 
         with self.assertRaisesRegex(ValueError, "does not have primary keys"):
             registrator.register(descriptor)
+
+
+class TestRegistratorPrimaryKeyGenerationRules(TestCase):
+
+    def test_register_enables_db_generation_for_int_primary_key(self):
+        kind = _make_model_class("GeneratedIntModel")
+        descriptor = _make_descriptor(
+            "GeneratedIntModel",
+            kind,
+            [
+                MAIntDescription(
+                    name="id",
+                    required=True,
+                    sa_isPrimaryKey=True,
+                )
+            ],
+        )
+
+        registry = registrator.register(descriptor)
+        table = registry.metadata.tables["GeneratedIntModel"]
+
+        self.assertIsNotNone(table.c.id.identity)
+
+    def test_register_enables_db_generation_for_scalar_single_option_int_primary_key(self):
+        kind = _make_model_class("GeneratedOptionModel")
+        descriptor = _make_descriptor(
+            "GeneratedOptionModel",
+            kind,
+            [
+                MASingleOptionDescription(
+                    name="status",
+                    required=True,
+                    sa_isPrimaryKey=True,
+                    reference=MAIntDescription(name="status_code", required=True),
+                )
+            ],
+        )
+
+        registry = registrator.register(descriptor)
+        table = registry.metadata.tables["GeneratedOptionModel"]
+
+        self.assertIsNotNone(table.c.status.identity)
+
+    def test_register_rejects_primary_keys_that_cannot_be_generated(self):
+        cases = [
+            (
+                "string",
+                MAStringDescription(name="name", required=True, sa_isPrimaryKey=True),
+            ),
+            (
+                "boolean",
+                MABooleanDescription(name="enabled", required=True, sa_isPrimaryKey=True),
+            ),
+        ]
+
+        for case_name, pk_description in cases:
+            with self.subTest(case_name=case_name):
+                kind = _make_model_class(f"Generated{case_name.title()}PkModel")
+                descriptor = _make_descriptor(
+                    f"Generated{case_name.title()}PkModel",
+                    kind,
+                    [pk_description],
+                )
+
+                with self.assertRaisesRegex(ValueError, "cannot auto-generate primary key"):
+                    registrator.register(descriptor)
+
+    def test_register_logs_warning_when_multiple_primary_keys_are_marked(self):
+        kind = _make_model_class("GeneratedCompositeModel")
+        descriptor = _make_descriptor(
+            "GeneratedCompositeModel",
+            kind,
+            [
+                MAIntDescription(
+                    name="left_id",
+                    required=True,
+                    sa_isPrimaryKey=True,
+                ),
+                MAIntDescription(
+                    name="right_id",
+                    required=True,
+                    sa_isPrimaryKey=True,
+                ),
+            ],
+        )
+
+        with patch("MagritteSQLAlchemy.imperative.fieldsmapper.logger.warning") as warning_mock:
+            registry = registrator.register(descriptor)
+
+        table = registry.metadata.tables["GeneratedCompositeModel"]
+        self.assertIsNotNone(table.c.left_id.identity)
+        self.assertIsNotNone(table.c.right_id.identity)
+        warning_mock.assert_called_once()
 
 
 class TestRegistratorExample(TestCase):


### PR DESCRIPTION
MagritteSQLAlchemy now supports DB-generated primary keys via container-level `sa_shouldGeneratePrimaryKey` flag.
If this flag is set, then a field marked with `sa_isPrimaryKey` will be reflected to a DB field with auto-initialization on DB side. Before, we used the heuristic "_if we have a single integer PK field, then it is probably a DB-generated ID_" for such a functionality. Now it is set explicitly.