### PR TITLE
No primary key generation anymore

### DIFF
--- a/Magritte/model_for_tests/ModelDescriptor_test.py
+++ b/Magritte/model_for_tests/ModelDescriptor_test.py
@@ -39,10 +39,12 @@ class TestModelDescriptorProvider(MADescriptionProvider):
         soft_desc_container.setChildren(
             [
                 MAStringDescription(
-                    name='name', label='Name', required=True, accessor=MAAttrAccessor('name')
+                    name='name', label='Name', required=True, accessor=MAAttrAccessor('name'),
+                    sa_isPrimaryKey=True,
                 ),
                 MAStringDescription(
-                    name='version', label='Version', required=True, accessor=MAAttrAccessor('version')
+                    name='version', label='Version', required=True, accessor=MAAttrAccessor('version'),
+                    sa_isPrimaryKey=True,
                 ),
                 MAStringDescription(
                     name='code', label='Code', accessor=MAAttrAccessor('code'), visible=False
@@ -344,4 +346,3 @@ if __name__ == "__main__":
             print(f"Validation failed with {err}: {err.description.name}, {err.message}")
     print("Validation complete.")
     print(f"Software packages: {soft}")
-

--- a/MagritteSQLAlchemy/imperative/registrator.py
+++ b/MagritteSQLAlchemy/imperative/registrator.py
@@ -1,5 +1,5 @@
 import logging
-from sqlalchemy import Table, Column, Integer
+from sqlalchemy import Table
 
 from Magritte.descriptions.MAContainer_class import MAContainer
 from sqlalchemy.orm import registry as sa_registry
@@ -9,12 +9,6 @@ from MagritteSQLAlchemy.imperative.propmapper import PropMapper
 
 logger = logging.getLogger(__name__)
 
-
-def add_missing_primary_keys(table: Table) -> Table:
-    if(len(table.primary_key) == 0):
-        logger.debug(f'Adding ID as default primary key to table {table.name} ({table.primary_key})')
-        table.append_column(Column("id", Integer, primary_key=True))
-    return table
 
 def register(
     *descriptors: MAContainer,
@@ -48,8 +42,8 @@ def register(
         # map scalar fields
         fields_mapper.map(descriptor, table)
 
-        # add missing primary keys
-        table = add_missing_primary_keys(table)
+        if len(table.primary_key) == 0:
+            raise ValueError(f'Table {table.name} does not have primary keys')
 
         logger.debug(f'Table columns for {descriptor.name}: {table.c}')
         logger.debug(f' ================= > Created table for {descriptor.name} ...')

--- a/MagritteSQLAlchemy/imperative/tests/mul2many_test.py
+++ b/MagritteSQLAlchemy/imperative/tests/mul2many_test.py
@@ -61,7 +61,12 @@ host_desc.name = "Host"
 host_desc.kind = Host
 host_desc.setChildren(
     [
-        MAStringDescription(name="ip", accessor=MAAttrAccessor("ip"), required=True),
+        MAStringDescription(
+            name="ip",
+            accessor=MAAttrAccessor("ip"),
+            required=True,
+            sa_isPrimaryKey=True,
+        ),
         MAToManyRelationDescription(
             name="users",
             accessor=MAAttrAccessor("users"),
@@ -81,7 +86,12 @@ user_desc.name = "User"
 user_desc.kind = User
 user_desc.setChildren(
     [
-        MAStringDescription(name="name", accessor=MAAttrAccessor("name"), required=True),
+        MAStringDescription(
+            name="name",
+            accessor=MAAttrAccessor("name"),
+            required=True,
+            sa_isPrimaryKey=True,
+        ),
         ]
     )
 

--- a/MagritteSQLAlchemy/imperative/tests/registrator_test.py
+++ b/MagritteSQLAlchemy/imperative/tests/registrator_test.py
@@ -8,6 +8,8 @@ from unittest import TestCase
 
 from sqlalchemy.sql.ddl import CreateSchema
 
+from Magritte.descriptions.MAContainer_class import MAContainer
+from Magritte.descriptions.MAStringDescription_class import MAStringDescription
 from Magritte.model_for_tests.ModelDescriptor_test import TestModelDescriptorProvider
 from Magritte.model_for_tests.EnvironmentProvider_test import TestEnvironmentProvider
 from Magritte.model_for_tests import (Organization, Host, User, Port, Account, SubscriptionPlan, SoftwarePackage, )
@@ -35,6 +37,27 @@ descriptions = {k: v for k, v in ((x, descriptors.description_for(x)) for x in m
 # engine = create_engine("sqlite://", echo=False)
 conn_str = f"{os.getenv('CONN_STR_BASE', 'postgresql://postgres:secret@localhost')}/registrator_test"
 engine = create_engine(conn_str, echo=True)
+
+
+class NoPkModel:
+    pass
+
+
+class TestRegistratorPrimaryKeyValidation(TestCase):
+
+    def test_register_raises_when_no_primary_key_is_defined(self):
+        descriptor = MAContainer()
+        descriptor.kind = NoPkModel
+        descriptor.name = "NoPkModel"
+        descriptor.setChildren(
+            [
+                MAStringDescription(name="name", required=True),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not have primary keys"):
+            registrator.register(descriptor)
+
 
 class TestRegistratorExample(TestCase):
 


### PR DESCRIPTION
If you try to register Magritte description with no PK fields (i.e., with no fields marked as `sa_isPrimaryKey=True`), you'll obtain an exception, not a silent under-the-hood adding of an ID fied.